### PR TITLE
Add support for OpenID Connect (OIDC).

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,11 @@ Alternatively, the parameters of the `::glowing_bear::params` class can be used 
 | `glowing_bear::app_url`       | | The address where the Glowing Bear application will be available. |
 | `glowing_bear::transmart_url` | | The address of the TranSMART back end application. |
 | `glowing_bear::env`           | `dev` | The Glowing Bear environment to use. [`default`, `dev`, `transmart`] |
-| `glowing_bear::tree_node_counts_update` | Glowing Bear default | Flag is tree node counts should be automatically updated.
-| `glowing_bear::autosave_subject_sets` | Glowing Bear default | Flag if subject selection should be automatically persisted.
-| `glowing_bear::export_data_view` | Glowing Bear default | Set data view for exports [`default`, `surveyTable`]
+| `glowing_bear::tree_node_counts_update` | Glowing Bear default | Flag is tree node counts should be automatically updated. |
+| `glowing_bear::autosave_subject_sets` | Glowing Bear default | Flag if subject selection should be automatically persisted. |
+| `glowing_bear::export_data_view` | Glowing Bear default | Set data view for exports [`default`, `surveyTable`] |
+| `glowing_bear::authentication_method` | `oauth2` | Authentication method [`oauth2`, `oidc`] |
+| `glowing_bear::oidc_server_url` | | Identity provider URL for when OpenID Connect is used for authentication. |
 
 Note that the modules only serves the application over plain HTTP, by configuring a simple Apache virtual host.
 For enabling HTTPS, a separate Apache instance needs to be setup as a proxy.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,9 @@ class glowing_bear::params(
     Optional[Boolean] $tree_node_counts_update                  = lookup('glowing_bear::tree_node_counts_update', Optional[Boolean], first, undef),
     Optional[Boolean] $autosave_subject_sets                    = lookup('glowing_bear::autosave_subject_sets', Optional[Boolean], first, undef),
     Optional[Enum['default', 'surveyTable']] $export_data_view  = lookup('glowing_bear::export_data_view', Optional[Enum['default','surveyTable']], first, undef),
+
+    Enum['oauth2', 'oidc'] $authentication_method = lookup('glowing_bear::authentication_method', Enum['oauth2', 'oidc'], first, 'oauth2'),
+    Optional[String] $oidc_server_url           = lookup('glowing_bear::oidc_server_url', Optional[String], first, undef),
 ) {
 
     if $app_url != undef {
@@ -24,6 +27,13 @@ class glowing_bear::params(
     } else {
         notify { "Warning: Glowing Bear on ${hostname} is configured without SSL!": }
         $application_url = "http://${hostname}"
+    }
+
+    if $authentication_method == 'oidc' {
+        # Check authentication settings
+        if $oidc_server_url == undef {
+            fail('No OpenID Connect server configured. Please configure glowing_bear::oidc_server_url')
+        }
     }
 
     # Set glowingbear user home directory

--- a/spec/classes/complete_spec.rb
+++ b/spec/classes/complete_spec.rb
@@ -10,4 +10,15 @@ describe 'glowing_bear::complete' do
     it { is_expected.to create_class('glowing_bear::config') }
     it { is_expected.to create_class('glowing_bear::vhost') }
   end
+  context 'with OpenID Connect (OIDC) configured without server url' do
+    let(:node) { 'test3.example.com' }
+    it { should compile.and_raise_error(/No OpenID Connect server configured/) }
+  end
+  context 'with OpenID Connect (OIDC) configured correctly' do
+    let(:node) { 'test4.example.com' }
+    it { is_expected.to create_class('glowing_bear::assets') }
+    it { is_expected.to create_class('glowing_bear::config') }
+    it { is_expected.to create_class('glowing_bear::vhost') }
+  end
+
 end

--- a/spec/fixtures/hieradata/test3.example.com.yaml
+++ b/spec/fixtures/hieradata/test3.example.com.yaml
@@ -1,0 +1,4 @@
+---
+glowing_bear::hostname: test3.example.com
+glowing_bear::transmart_url: https://transmart.example.com
+glowing_bear::authentication_method: oidc

--- a/spec/fixtures/hieradata/test4.example.com.yaml
+++ b/spec/fixtures/hieradata/test4.example.com.yaml
@@ -1,0 +1,5 @@
+---
+glowing_bear::hostname: test3.example.com
+glowing_bear::transmart_url: https://transmart.example.com
+glowing_bear::authentication_method: oidc
+glowing_bear::oidc_server_url: https://idp.example.com

--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -6,3 +6,10 @@ node 'test2.example.com' {
     include ::glowing_bear
 }
 
+node 'test3.example.com' {
+    include ::glowing_bear
+}
+
+node 'test4.example.com' {
+    include ::glowing_bear
+}

--- a/templates/config.json.erb
+++ b/templates/config.json.erb
@@ -2,8 +2,11 @@
   "api-url": "<%= scope.lookupvar('::glowing_bear::params::transmart_url') %>",
   "api-version": "v2",
   "app-url": "<%= scope.lookupvar('::glowing_bear::params::application_url') %>",
-  "authentication-method": "oauth2"<%
-   if scope.lookupvar('::glowing_bear::params::tree_node_counts_update') != nil %>,
+  "authentication-method": "<%= scope.lookupvar('::glowing_bear::params::authentication_method') %>"<%
+   if scope.lookupvar('::glowing_bear::params::authentication_method') == 'oidc' %>,
+  "oidc-server-url": "<%= scope.lookupvar('::glowing_bear::params::oidc_server_url') %>",
+  "oidc-client-id": "glowingbear-js"<% end -%>
+  <% if scope.lookupvar('::glowing_bear::params::tree_node_counts_update') != nil %>,
   "tree-node-counts-update": <%= scope.lookupvar('::glowing_bear::params::tree_node_counts_update').to_s %><% end -%>
   <% if scope.lookupvar('::glowing_bear::params::autosave_subject_sets') != nil %>,
   "autosave-subject-sets": <%= scope.lookupvar('::glowing_bear::params::autosave_subject_sets').to_s %><% end -%>


### PR DESCRIPTION
Enables configuring an authentication workflow (recently added to Glowing Bear). Defaults to `oauth2`. The other option is OpenID Connect (`oidc`).